### PR TITLE
`vppcfg`: Initial `vppcfg` derivation.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -10,14 +10,14 @@
 
 let
   vpp-pkgs = pkgs.callPackage ./pkgs/vpp { };
-in
-{
+in rec {
   # The `lib`, `modules`, and `overlay` names are special
   lib = import ./lib { inherit pkgs; }; # functions
   modules = import ./modules; # NixOS modules
   overlays = import ./overlays; # nixpkgs overlays
 
   vpp = vpp-pkgs.vpp;
+  vppcfg = pkgs.callPackage ./pkgs/vppcfg { inherit vpp-pkgs; };
 
   python3Packages = {
     # Marker for ci.nix to also build this.

--- a/pkgs/vpp/default.nix
+++ b/pkgs/vpp/default.nix
@@ -87,6 +87,7 @@ in rec {
     inherit src;
     sourceRoot = "source/src/vpp-api/python";
 
+    propagatedBuildInputs = with pkgs.python3Packages; [ setuptools ];
     nativeBuildInputs = [ 
       # Only needed if we'd actually build the JSON API Schemas, but instead we just depend on vpp.
       #ply

--- a/pkgs/vppcfg/default.nix
+++ b/pkgs/vppcfg/default.nix
@@ -1,0 +1,17 @@
+{ stdenv, pkgs,
+vpp-pkgs }:
+
+with pkgs.python3Packages;
+
+buildPythonPackage rec {
+  pname = "vppcfg";
+  version = "0.0.2-vifino";
+  src = pkgs.fetchFromGitHub {
+    owner = "vifino";
+    repo = "vppcfg";
+    rev = "9517b8dddd62a30fe8809a43c914387a8b34dc4f";
+    hash = "sha256-quP0O2X43cgb1yqtpLe89Rq02bBqUzSP/XyIH3zoRko=";
+  };
+
+  propagatedBuildInputs = [ requests yamale netaddr vpp-pkgs.vpp_papi ];
+}

--- a/pkgs/vppcfg/default.nix
+++ b/pkgs/vppcfg/default.nix
@@ -5,12 +5,12 @@ with pkgs.python3Packages;
 
 buildPythonPackage rec {
   pname = "vppcfg";
-  version = "0.0.2-vifino";
+  version = "0.0.2";
   src = pkgs.fetchFromGitHub {
-    owner = "vifino";
+    owner = "pimvanpelt";
     repo = "vppcfg";
-    rev = "9517b8dddd62a30fe8809a43c914387a8b34dc4f";
-    hash = "sha256-quP0O2X43cgb1yqtpLe89Rq02bBqUzSP/XyIH3zoRko=";
+    rev = "c10b7bbabb8d65e4cfa83a4b88de95bb4370e933";
+    hash = "sha256-YFfLUBxdC30YbmB0EQKXOZE5a+hOW2hSI641poVfybM=";
   };
 
   propagatedBuildInputs = [ requests yamale netaddr vpp-pkgs.vpp_papi ];


### PR DESCRIPTION
I forked `vppcfg` to make it use the `vpp_papi` API searcher functions and to remove a useless dependency.

Not sure how functional it is, but it's going in the right direction.